### PR TITLE
refactor: enable `verbatimModuleSyntax` for `core`

### DIFF
--- a/packages/core/src/lib/components/form-content/form-content.component.ts
+++ b/packages/core/src/lib/components/form-content/form-content.component.ts
@@ -1,8 +1,8 @@
 import { Directive } from '@angular/core';
-import { FormGroup } from '@angular/forms';
-import { AnyObject } from '@ngify/types';
+import type { FormGroup } from '@angular/forms';
+import type { AnyObject } from '@ngify/types';
 import { TemplateRefHolder } from '../../directives';
-import { AbstractSchema } from '../../schemas';
+import type { AbstractSchema } from '../../schemas';
 
 export interface FormContentTemplateContext {
   form: FormGroup;

--- a/packages/core/src/lib/components/form-item-content/form-item-content.component.ts
+++ b/packages/core/src/lib/components/form-item-content/form-item-content.component.ts
@@ -1,8 +1,8 @@
 import { Directive } from '@angular/core';
-import { AbstractControl } from '@angular/forms';
-import { AnyObject } from '@ngify/types';
+import type { AbstractControl } from '@angular/forms';
+import type { AnyObject } from '@ngify/types';
 import { TemplateRefHolder } from '../../directives';
-import { AbstractSchema } from '../../schemas';
+import type { AbstractSchema } from '../../schemas';
 
 export interface FormItemContentContext {
   control: AbstractControl;

--- a/packages/core/src/lib/components/form/form.component.ts
+++ b/packages/core/src/lib/components/form/form.component.ts
@@ -1,9 +1,9 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, DestroyRef, EnvironmentInjector, Injector, computed, createComponent, effect, inject, input, model, output, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControlStatus, FormGroup } from '@angular/forms';
-import { AnyObject } from '@ngify/types';
-import { AbstractFormGroupSchema } from '../../schemas';
+import { type FormControlStatus, FormGroup } from '@angular/forms';
+import type { AnyObject } from '@ngify/types';
+import type { AbstractFormGroupSchema } from '../../schemas';
 import { FLUENT_FORM_CONTENT, NAMED_TEMPLATES } from '../../tokens';
 import { FormUtil, ModelUtil, SchemaUtil } from '../../utils';
 

--- a/packages/core/src/lib/compose/builder.ts
+++ b/packages/core/src/lib/compose/builder.ts
@@ -1,4 +1,4 @@
-import { AnyObject, SafeAny } from '@ngify/types';
+import type { AnyObject, SafeAny } from '@ngify/types';
 
 interface Schema {
   [k: string]: SafeAny;

--- a/packages/core/src/lib/compose/component-container.ts
+++ b/packages/core/src/lib/compose/component-container.ts
@@ -1,6 +1,6 @@
-import { RowComponentSchema, SingleSchemaKey } from '../schemas';
-import { UnstableBuilder, composeBuilder } from './builder';
-import { KindOrKey } from './helper';
+import type { RowComponentSchema, SingleSchemaKey } from '../schemas';
+import { type UnstableBuilder, composeBuilder } from './builder';
+import type { KindOrKey } from './helper';
 
 export function row<Key extends SingleSchemaKey>(key?: Key): UnstableBuilder<RowComponentSchema<Key>, KindOrKey> {
   return composeBuilder<RowComponentSchema<Key>>().kind('row').key(key);

--- a/packages/core/src/lib/compose/control-container.ts
+++ b/packages/core/src/lib/compose/control-container.ts
@@ -1,7 +1,7 @@
-import { computed, Signal } from '@angular/core';
-import { SafeAny } from '@ngify/types';
-import { AbstractFormGroupSchema, AbstractSchema } from '../schemas';
-import { Indexable } from '../types';
+import { computed, type Signal } from '@angular/core';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractFormGroupSchema, AbstractSchema } from '../schemas';
+import type { Indexable } from '../types';
 import { isArray } from '../utils';
 import { composeBuilder } from './builder';
 

--- a/packages/core/src/lib/compose/control.ts
+++ b/packages/core/src/lib/compose/control.ts
@@ -1,6 +1,6 @@
-import { HeadlessControlSchema, SingleSchemaKey } from '../schemas';
-import { UnstableBuilder, composeBuilder } from './builder';
-import { KindOrKey } from './helper';
+import type { HeadlessControlSchema, SingleSchemaKey } from '../schemas';
+import { type UnstableBuilder, composeBuilder } from './builder';
+import type { KindOrKey } from './helper';
 
 export function headless<Key extends SingleSchemaKey>(key?: Key): UnstableBuilder<HeadlessControlSchema<Key>, KindOrKey> {
   return composeBuilder<HeadlessControlSchema<Key>>().kind('headless').key(key);

--- a/packages/core/src/lib/directives/binding.directive.ts
+++ b/packages/core/src/lib/directives/binding.directive.ts
@@ -1,10 +1,10 @@
-import { DestroyRef, Directive, ElementRef, Input, OnChanges, OnInit, OutputRef, inject, isSignal } from '@angular/core';
-import { SIGNAL, SignalNode, signalSetFn } from '@angular/core/primitives/signals';
+import { DestroyRef, Directive, ElementRef, Input, type OnChanges, type OnInit, type OutputRef, inject, isSignal } from '@angular/core';
+import { SIGNAL, type SignalNode, signalSetFn } from '@angular/core/primitives/signals';
 import { outputToObservable } from '@angular/core/rxjs-interop';
 import { AbstractControl } from '@angular/forms';
-import { AnyObject, SafeAny } from '@ngify/types';
+import type { AnyObject, SafeAny } from '@ngify/types';
 import { Observable, fromEvent, map, takeUntil } from 'rxjs';
-import { AbstractSchema, EventListenerHolder, EventObserverHolder, HooksHolder, PropertyHolder, SchemaContext } from '../schemas';
+import type { AbstractSchema, EventListenerHolder, EventObserverHolder, HooksHolder, PropertyHolder, SchemaContext } from '../schemas';
 import { DestroyedSubject } from '../services';
 
 function isHookHolder(value: SafeAny): value is Required<HooksHolder> {

--- a/packages/core/src/lib/directives/form-item-outlet.directive.ts
+++ b/packages/core/src/lib/directives/form-item-outlet.directive.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { Directive, EnvironmentInjector, Injector, createComponent, inject } from '@angular/core';
-import { SafeAny } from '@ngify/types';
+import type { SafeAny } from '@ngify/types';
 import { FLUENT_FORM_ITEM_CONTENT } from '../tokens';
 
 @Directive({

--- a/packages/core/src/lib/directives/grid/col/col.component.ts
+++ b/packages/core/src/lib/directives/grid/col/col.component.ts
@@ -1,7 +1,7 @@
 import { Component, Directive, ViewEncapsulation, computed, input } from '@angular/core';
 import { Breakpoints, createBreakpointInfix } from '../../../breakpoints';
 import { withStyle } from '../../../style';
-import { Stringify } from '../../../types';
+import type { Stringify } from '../../../types';
 import { isObject } from '../../../utils';
 
 type Cell = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;

--- a/packages/core/src/lib/directives/grid/row/row.component.ts
+++ b/packages/core/src/lib/directives/grid/row/row.component.ts
@@ -4,7 +4,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
 import { Breakpoints } from '../../../breakpoints';
 import { withStyle } from '../../../style';
-import { Stringify } from '../../../types';
+import type { Stringify } from '../../../types';
 import { isArray, isNumber, isString } from '../../../utils';
 
 type Gap = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/packages/core/src/lib/directives/render/form.directive.ts
+++ b/packages/core/src/lib/directives/render/form.directive.ts
@@ -1,8 +1,8 @@
 import { computed, DestroyRef, Directive, effect, forwardRef, HostListener, inject, input, model, output, untracked } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControlStatus, FormGroup } from '@angular/forms';
-import { AnyArray, AnyObject } from '@ngify/types';
-import { AbstractFormGroupSchema } from '../../schemas';
+import { type FormControlStatus, FormGroup } from '@angular/forms';
+import type { AnyArray, AnyObject } from '@ngify/types';
+import type { AbstractFormGroupSchema } from '../../schemas';
 import { NAMED_TEMPLATES } from '../../tokens';
 import { FormUtil, ModelUtil } from '../../utils';
 import { FluentControlContainer, FluentControlContainerDirective } from './models/control-container';

--- a/packages/core/src/lib/directives/render/models/control-container.ts
+++ b/packages/core/src/lib/directives/render/models/control-container.ts
@@ -1,7 +1,7 @@
-import { Directive, Signal, inject } from '@angular/core';
+import { Directive, type Signal, inject } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { AnyArray, AnyObject } from '@ngify/types';
-import { AbstractControlContainerSchema } from '../../../schemas';
+import type { AnyArray, AnyObject } from '@ngify/types';
+import type { AbstractControlContainerSchema } from '../../../schemas';
 import { SchemaUtil } from '../../../utils';
 import { FluentOutletDirective } from '../outlet.directive';
 

--- a/packages/core/src/lib/directives/render/outlet.directive.ts
+++ b/packages/core/src/lib/directives/render/outlet.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, inject, Input, OnChanges, OnDestroy, OnInit, ViewContainerRef } from '@angular/core';
+import { Directive, inject, Input, type OnChanges, type OnDestroy, type OnInit, ViewContainerRef } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { AnyArray, AnyObject } from '@ngify/types';
-import { AbstractSchema, SingleSchemaKey } from '../../schemas';
+import type { AnyArray, AnyObject } from '@ngify/types';
+import type { AbstractSchema, SingleSchemaKey } from '../../schemas';
 import { WidgetTemplateRegistry } from '../../services';
-import { WidgetTemplateContext } from '../../widgets';
+import type { WidgetTemplateContext } from '../../widgets';
 import { FluentControlContainer } from './models/control-container';
 
 @Directive({

--- a/packages/core/src/lib/directives/template.directive.ts
+++ b/packages/core/src/lib/directives/template.directive.ts
@@ -1,4 +1,4 @@
-import { DestroyRef, Directive, TemplateRef, inject, input, OnInit } from '@angular/core';
+import { DestroyRef, Directive, TemplateRef, inject, input, type OnInit } from '@angular/core';
 import { NAMED_TEMPLATES } from '../tokens';
 
 @Directive({

--- a/packages/core/src/lib/features/helper.ts
+++ b/packages/core/src/lib/features/helper.ts
@@ -1,5 +1,5 @@
-import { Provider } from '@angular/core';
-import { FluentFormFeature, FluentFormFeatureKind } from './interface';
+import type { Provider } from '@angular/core';
+import { type FluentFormFeature, FluentFormFeatureKind } from './interface';
 
 export function makeFluentFeature<K extends FluentFormFeatureKind>(kind: K, providers: Provider[]): FluentFormFeature<K> {
   return { kind, providers };

--- a/packages/core/src/lib/features/interface.ts
+++ b/packages/core/src/lib/features/interface.ts
@@ -1,4 +1,4 @@
-import { Provider } from '@angular/core';
+import type { Provider } from '@angular/core';
 
 export const enum FluentFormFeatureKind {
   UIAdapter,

--- a/packages/core/src/lib/features/schema-patcher.feature.ts
+++ b/packages/core/src/lib/features/schema-patcher.feature.ts
@@ -1,7 +1,7 @@
-import { Provider } from '@angular/core';
-import { SchemaPatcher, provideSchemaPatcher } from '../patcher';
+import type { Provider } from '@angular/core';
+import { type SchemaPatcher, provideSchemaPatcher } from '../patcher';
 import { makeFluentFeature } from './helper';
-import { FluentFormFeature, FluentFormFeatureKind } from './interface';
+import { type FluentFormFeature, FluentFormFeatureKind } from './interface';
 
 export function withSchemaPatchers(patchers: (SchemaPatcher | SchemaPatcher[])[]): FluentFormFeature<FluentFormFeatureKind.SchemaPatcher> {
   return makeFluentFeature(

--- a/packages/core/src/lib/features/static-expression.feature.ts
+++ b/packages/core/src/lib/features/static-expression.feature.ts
@@ -1,6 +1,6 @@
 import { CodeEvaluator, DynamicCodeEvaluator } from '../services';
 import { makeFluentFeature } from './helper';
-import { FluentFormFeature, FluentFormFeatureKind } from './interface';
+import { type FluentFormFeature, FluentFormFeatureKind } from './interface';
 
 export function withStaticExpression(): FluentFormFeature<FluentFormFeatureKind.StaticExpression> {
   return makeFluentFeature(FluentFormFeatureKind.StaticExpression, [

--- a/packages/core/src/lib/features/widget-configs.feature.ts
+++ b/packages/core/src/lib/features/widget-configs.feature.ts
@@ -1,8 +1,8 @@
-import { Provider, Type } from '@angular/core';
-import { SafeAny } from '@ngify/types';
-import { SchemaConfig } from '../interfaces';
-import { SchemaPatchFn, provideSchemaPatcher } from '../patcher';
-import { AbstractSchema } from '../schemas';
+import type { Provider, Type } from '@angular/core';
+import type { SafeAny } from '@ngify/types';
+import type { SchemaConfig } from '../interfaces';
+import { type SchemaPatchFn, provideSchemaPatcher } from '../patcher';
+import type { AbstractSchema } from '../schemas';
 import { SchemaKind, SchemaType } from '../schemas/interfaces';
 import { SCHEMA_MAP, WIDGET_MAP } from '../tokens';
 import { AbstractWidget, useRowWidget } from '../widgets';

--- a/packages/core/src/lib/interfaces.ts
+++ b/packages/core/src/lib/interfaces.ts
@@ -1,6 +1,6 @@
-import { ValidatorFn } from '@angular/forms';
-import { AbstractSchema } from './schemas';
-import { SchemaType } from './schemas/interfaces';
+import type { ValidatorFn } from '@angular/forms';
+import type { AbstractSchema } from './schemas';
+import type { SchemaType } from './schemas/interfaces';
 
 export interface SchemaConfig<S extends AbstractSchema> {
   type: SchemaType;

--- a/packages/core/src/lib/patcher/interfaces.ts
+++ b/packages/core/src/lib/patcher/interfaces.ts
@@ -1,5 +1,5 @@
-import { SafeAny } from '@ngify/types';
-import { AbstractSchema, SchemaType } from '../schemas';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractSchema, SchemaType } from '../schemas';
 
 export type SchemaSelector = '*' | string | SchemaType | (string | SchemaType)[];
 

--- a/packages/core/src/lib/patcher/provider.ts
+++ b/packages/core/src/lib/patcher/provider.ts
@@ -1,5 +1,5 @@
-import { InjectionToken, Provider } from '@angular/core';
-import { SchemaPatcher } from './interfaces';
+import { InjectionToken, type Provider } from '@angular/core';
+import type { SchemaPatcher } from './interfaces';
 
 export const SCHEMA_PATCHERS = new InjectionToken<SchemaPatcher[]>('SchemaPatchers');
 

--- a/packages/core/src/lib/pipes/col.pipe.ts
+++ b/packages/core/src/lib/pipes/col.pipe.ts
@@ -1,5 +1,5 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { AbstractSchema, Column } from '../schemas';
+import { Pipe, type PipeTransform } from '@angular/core';
+import type { AbstractSchema, Column } from '../schemas';
 import { isObject } from '../utils';
 
 function isColumn(value: object): value is Column {

--- a/packages/core/src/lib/pipes/control.pipe.ts
+++ b/packages/core/src/lib/pipes/control.pipe.ts
@@ -1,6 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, type PipeTransform } from '@angular/core';
 import { AbstractControl, FormArray, FormControl, FormGroup } from '@angular/forms';
-import { SchemaKey } from '../schemas';
+import type { SchemaKey } from '../schemas';
 import { getChildControl, isUndefined } from '../utils';
 
 /**

--- a/packages/core/src/lib/pipes/inject.pipe.ts
+++ b/packages/core/src/lib/pipes/inject.pipe.ts
@@ -1,4 +1,4 @@
-import { inject, InjectOptions, Injector, Pipe, PipeTransform, ProviderToken } from '@angular/core';
+import { inject, type InjectOptions, Injector, Pipe, type PipeTransform, type ProviderToken } from '@angular/core';
 
 /**
  * @internal

--- a/packages/core/src/lib/pipes/invoke.pipe.ts
+++ b/packages/core/src/lib/pipes/invoke.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, type PipeTransform } from '@angular/core';
 
 /**
  * @internal

--- a/packages/core/src/lib/pipes/new.pipe.ts
+++ b/packages/core/src/lib/pipes/new.pipe.ts
@@ -1,5 +1,5 @@
-import { inject, Injector, Pipe, PipeTransform, runInInjectionContext, Type } from '@angular/core';
-import { SafeAny } from '@ngify/types';
+import { inject, Injector, Pipe, type PipeTransform, runInInjectionContext, Type } from '@angular/core';
+import type { SafeAny } from '@ngify/types';
 
 /**
  * @internal

--- a/packages/core/src/lib/pipes/reactive.pipe.ts
+++ b/packages/core/src/lib/pipes/reactive.pipe.ts
@@ -1,7 +1,7 @@
-import { inject, Pipe, PipeTransform } from '@angular/core';
+import { inject, Pipe, type PipeTransform } from '@angular/core';
 import { AbstractControl } from '@angular/forms';
-import { SafeAny } from '@ngify/types';
-import { AbstractSchema, MaybeSchemaReactiveFn } from '../schemas';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractSchema, MaybeSchemaReactiveFn } from '../schemas';
 import { ValueTransformer } from '../services';
 
 /**

--- a/packages/core/src/lib/pipes/renderable.pipe.ts
+++ b/packages/core/src/lib/pipes/renderable.pipe.ts
@@ -1,5 +1,5 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { AbstractSchema, SchemaKind } from '../schemas';
+import { Pipe, type PipeTransform } from '@angular/core';
+import { type AbstractSchema, SchemaKind } from '../schemas';
 
 @Pipe({
   name: 'renderable',

--- a/packages/core/src/lib/pipes/schema-type.pipe.ts
+++ b/packages/core/src/lib/pipes/schema-type.pipe.ts
@@ -1,4 +1,4 @@
-import { inject, Pipe, PipeTransform } from '@angular/core';
+import { inject, Pipe, type PipeTransform } from '@angular/core';
 import { SchemaType } from '../schemas/interfaces';
 import { SCHEMA_MAP } from '../tokens';
 

--- a/packages/core/src/lib/pipes/schema.pipe.ts
+++ b/packages/core/src/lib/pipes/schema.pipe.ts
@@ -1,6 +1,6 @@
-import { inject, Pipe, PipeTransform } from '@angular/core';
-import { AbstractBranchSchema, AbstractControlContainerSchema, AbstractControlSchema, SchemaKey, SingleSchemaKey } from '../schemas';
-import { Indexable } from '../types';
+import { inject, Pipe, type PipeTransform } from '@angular/core';
+import type { AbstractBranchSchema, AbstractControlContainerSchema, AbstractControlSchema, SchemaKey, SingleSchemaKey } from '../schemas';
+import type { Indexable } from '../types';
 import { SchemaUtil } from '../utils';
 
 /**

--- a/packages/core/src/lib/pipes/template.pipe.ts
+++ b/packages/core/src/lib/pipes/template.pipe.ts
@@ -1,5 +1,5 @@
-import { inject, Pipe, PipeTransform, TemplateRef } from '@angular/core';
-import { SafeAny } from '@ngify/types';
+import { inject, Pipe, type PipeTransform, TemplateRef } from '@angular/core';
+import type { SafeAny } from '@ngify/types';
 import { NAMED_TEMPLATES } from '../tokens';
 import { isString } from '../utils';
 

--- a/packages/core/src/lib/pipes/widget-template.pipe.ts
+++ b/packages/core/src/lib/pipes/widget-template.pipe.ts
@@ -1,10 +1,10 @@
-import { inject, Pipe, PipeTransform, TemplateRef } from '@angular/core';
+import { inject, Pipe, type PipeTransform, TemplateRef } from '@angular/core';
 import { throwCustomTemplateNotFoundError } from '../errors';
-import { AbstractSchema } from '../schemas';
+import type { AbstractSchema } from '../schemas';
 import { SchemaKind } from '../schemas/interfaces';
 import { WidgetTemplateRegistry } from '../services';
 import { NAMED_TEMPLATES } from '../tokens';
-import { Indexable } from '../types';
+import type { Indexable } from '../types';
 
 /**
  * @internal

--- a/packages/core/src/lib/provider.ts
+++ b/packages/core/src/lib/provider.ts
@@ -1,5 +1,5 @@
 import { makeEnvironmentProviders } from '@angular/core';
-import { FluentFormFeature, FluentFormFeatureKind } from './features';
+import { type FluentFormFeature, FluentFormFeatureKind } from './features';
 
 export function provideFluentForm(...features: FluentFormFeature<FluentFormFeatureKind>[]) {
   return makeEnvironmentProviders([

--- a/packages/core/src/lib/schemas/abstract.schema.ts
+++ b/packages/core/src/lib/schemas/abstract.schema.ts
@@ -1,10 +1,10 @@
-import { SafeAny } from '@ngify/types';
-import { FluentColDirective } from '../directives';
-import { Indexable } from '../types';
-import { Column } from './grid';
-import { HooksHolder } from './hooks';
-import { MaybeSchemaReactiveFn, SchemaLike } from './interfaces';
-import { SchemaKey } from './types';
+import type { SafeAny } from '@ngify/types';
+import type { FluentColDirective } from '../directives';
+import type { Indexable } from '../types';
+import type { Column } from './grid';
+import type { HooksHolder } from './hooks';
+import type { MaybeSchemaReactiveFn, SchemaLike } from './interfaces';
+import type { SchemaKey } from './types';
 
 /**
  * 抽象图示

--- a/packages/core/src/lib/schemas/component-container.schema.ts
+++ b/packages/core/src/lib/schemas/component-container.schema.ts
@@ -1,9 +1,9 @@
-import { AbstractBranchSchema } from './abstract.schema';
-import { Row } from './grid';
-import { ElementEventListenerHolder } from './listeners';
-import { ElementEventObserverHolder } from './observers';
-import { ElementPropertyHolder } from './properties';
-import { SingleSchemaKey } from './types';
+import type { AbstractBranchSchema } from './abstract.schema';
+import type { Row } from './grid';
+import type { ElementEventListenerHolder } from './listeners';
+import type { ElementEventObserverHolder } from './observers';
+import type { ElementPropertyHolder } from './properties';
+import type { SingleSchemaKey } from './types';
 
 /**
  * @public

--- a/packages/core/src/lib/schemas/component-wrapper.schema.ts
+++ b/packages/core/src/lib/schemas/component-wrapper.schema.ts
@@ -1,5 +1,5 @@
-import { AbstractBranchSchema } from './abstract.schema';
-import { SingleSchemaKey } from './types';
+import type { AbstractBranchSchema } from './abstract.schema';
+import type { SingleSchemaKey } from './types';
 
 /**
  * @public

--- a/packages/core/src/lib/schemas/component.ts
+++ b/packages/core/src/lib/schemas/component.ts
@@ -1,4 +1,4 @@
-import { AbstractSchema } from './abstract.schema';
-import { SingleSchemaKey } from './types';
+import type { AbstractSchema } from './abstract.schema';
+import type { SingleSchemaKey } from './types';
 
 export type AbstractComponentSchema<Key extends SingleSchemaKey = SingleSchemaKey> = AbstractSchema<Key>;

--- a/packages/core/src/lib/schemas/control-container.schema.ts
+++ b/packages/core/src/lib/schemas/control-container.schema.ts
@@ -1,11 +1,11 @@
-import { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
-import { SafeAny } from '@ngify/types';
-import { AbstractBranchSchema } from './abstract.schema';
-import { Row } from './grid';
-import { Length } from './interfaces';
-import { ControlEventListenerHolder } from './listeners';
-import { ControlEventObserverHolder } from './observers';
-import { SingleSchemaKey } from './types';
+import type { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractBranchSchema } from './abstract.schema';
+import type { Row } from './grid';
+import type { Length } from './interfaces';
+import type { ControlEventListenerHolder } from './listeners';
+import type { ControlEventObserverHolder } from './observers';
+import type { SingleSchemaKey } from './types';
 
 /**
  * @public

--- a/packages/core/src/lib/schemas/control-wrapper.schema.ts
+++ b/packages/core/src/lib/schemas/control-wrapper.schema.ts
@@ -1,7 +1,7 @@
-import { Indexable } from '../types';
-import { AbstractBranchSchema } from './abstract.schema';
-import { AbstractControlSchema } from './control.schema';
-import { SingleSchemaKey } from './types';
+import type { Indexable } from '../types';
+import type { AbstractBranchSchema } from './abstract.schema';
+import type { AbstractControlSchema } from './control.schema';
+import type { SingleSchemaKey } from './types';
 
 /**
  * @public

--- a/packages/core/src/lib/schemas/control.schema.ts
+++ b/packages/core/src/lib/schemas/control.schema.ts
@@ -1,14 +1,13 @@
-import { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
-import { SafeAny } from '@ngify/types';
-import { AbstractSchema } from './abstract.schema';
-import { MaybeSchemaReactiveFn, SchemaReactiveFn } from './interfaces';
-import { ControlValueMapper } from './mapper';
-import { PropertyHolder } from './properties';
-import { SchemaKey, SingleSchemaKey } from './types';
+import type { AbstractControlOptions, AsyncValidatorFn, ValidatorFn } from '@angular/forms';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractSchema } from './abstract.schema';
+import type { MaybeSchemaReactiveFn, SchemaReactiveFn } from './interfaces';
+import type { ControlValueMapper } from './mapper';
+import type { PropertyHolder } from './properties';
+import type { SchemaKey, SingleSchemaKey } from './types';
 
 /**
- * @public
- * 抽象的真实控件图示
+ * Abstract representation of a real (concrete) control schema.
  */
 export interface AbstractControlSchema<Key extends SchemaKey = SchemaKey, Val = SafeAny> extends AbstractSchema<Key> {
   id?: string;

--- a/packages/core/src/lib/schemas/grid.ts
+++ b/packages/core/src/lib/schemas/grid.ts
@@ -1,4 +1,4 @@
-import { FluentColDirective, FluentRowDirective } from '../directives';
+import type { FluentColDirective, FluentRowDirective } from '../directives';
 
 export interface Row {
   align?: ReturnType<FluentRowDirective['align']>;

--- a/packages/core/src/lib/schemas/hooks.ts
+++ b/packages/core/src/lib/schemas/hooks.ts
@@ -1,4 +1,4 @@
-import { SchemaContext, SchemaLike } from './interfaces';
+import type { SchemaContext, SchemaLike } from './interfaces';
 
 export interface HooksHolder<S extends SchemaLike = SchemaLike> {
   hooks?: {

--- a/packages/core/src/lib/schemas/interfaces.ts
+++ b/packages/core/src/lib/schemas/interfaces.ts
@@ -1,7 +1,7 @@
 import { AbstractControl } from '@angular/forms';
-import { SafeAny } from '@ngify/types';
-import { AbstractSchema } from './abstract.schema';
-import { SchemaKey } from './types';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractSchema } from './abstract.schema';
+import type { SchemaKey } from './types';
 
 /**
  * @public
@@ -30,7 +30,10 @@ export interface SchemaLike<Key extends SchemaKey = SchemaKey> {
 
 export interface SchemaContext<S extends SchemaLike = AbstractSchema> {
   schema: S;
-  /** 如果当前没有对应的 control，会返回上一级的 control，这时候一般是 form group/array */
+  /**
+   * If there is no corresponding control, the parent control will be returned,
+   * usually a `FormGroup` or `FormArray`.
+   */
   control: AbstractControl;
   model: SafeAny;
 }

--- a/packages/core/src/lib/schemas/listeners.ts
+++ b/packages/core/src/lib/schemas/listeners.ts
@@ -1,7 +1,7 @@
-import { FormControlStatus } from '@angular/forms';
-import { SafeAny } from '@ngify/types';
-import { ComponentOutputMap } from '../types';
-import { SchemaContext } from './interfaces';
+import type { FormControlStatus } from '@angular/forms';
+import type { SafeAny } from '@ngify/types';
+import type { ComponentOutputMap } from '../types';
+import type { SchemaContext } from './interfaces';
 
 type ControlEventListenerMap<Val> = {
   valueChange?: (value: Val, context: SchemaContext) => void;

--- a/packages/core/src/lib/schemas/mapper.ts
+++ b/packages/core/src/lib/schemas/mapper.ts
@@ -1,5 +1,5 @@
-import { SafeAny } from '@ngify/types';
-import { AbstractControlSchema } from './control.schema';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractControlSchema } from './control.schema';
 
 export interface ControlValueMapper<V> {
   /** A parser that maps from a model's value to a form control's value */

--- a/packages/core/src/lib/schemas/observers.ts
+++ b/packages/core/src/lib/schemas/observers.ts
@@ -1,8 +1,8 @@
-import { FormControlStatus } from '@angular/forms';
-import { SafeAny } from '@ngify/types';
-import { Observable } from 'rxjs';
-import { ComponentOutputMap } from '../types';
-import { SchemaContext } from './interfaces';
+import type { FormControlStatus } from '@angular/forms';
+import type { SafeAny } from '@ngify/types';
+import type { Observable } from 'rxjs';
+import type { ComponentOutputMap } from '../types';
+import type { SchemaContext } from './interfaces';
 
 type ControlEventObserverMap<Val> = {
   valueChange?: (source: Observable<{ event: Val, context: SchemaContext }>) => Observable<SafeAny>;

--- a/packages/core/src/lib/schemas/properties.ts
+++ b/packages/core/src/lib/schemas/properties.ts
@@ -1,5 +1,5 @@
-import { SafeAny } from '@ngify/types';
-import { ComponentPropertyMap, HTMLElementPropertyMap } from '../types';
+import type { SafeAny } from '@ngify/types';
+import type { ComponentPropertyMap, HTMLElementPropertyMap } from '../types';
 
 /** 属性修补器 */
 export interface PropertyHolder {

--- a/packages/core/src/lib/schemas/types.ts
+++ b/packages/core/src/lib/schemas/types.ts
@@ -1,6 +1,8 @@
-/** 任意字段控件名称 */
+/** Name of any kind of field control */
 export type SchemaKey = SingleSchemaKey | MultiSchemaKey;
-/** 单字段图示名称 */
+
+/** Name of a single-field schema */
 export type SingleSchemaKey = string | number;
-/** 多字段图示名称 */
+
+/** Name of a multi-field schema */
 export type MultiSchemaKey = readonly string[];

--- a/packages/core/src/lib/services/destroyed.service.spec.ts
+++ b/packages/core/src/lib/services/destroyed.service.spec.ts
@@ -1,3 +1,5 @@
+import { Injector, runInInjectionContext } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { delay, finalize, of, takeUntil } from 'rxjs';
 import { DestroyedSubject } from './destroyed.service';
 
@@ -6,7 +8,7 @@ describe('DestroyedSubject', () => {
   const initObservable = of('done');
 
   beforeEach(() => {
-    destroyed$ = new DestroyedSubject();
+    destroyed$ = runInInjectionContext(TestBed.inject(Injector), () => new DestroyedSubject());
   });
 
   it('should subscribe work normal', () => {
@@ -32,7 +34,7 @@ describe('DestroyedSubject', () => {
       )
       .subscribe();
 
-    destroyed$.ngOnDestroy();
+    TestBed.resetTestingModule();
 
     expect(result).toBe('final');
   });

--- a/packages/core/src/lib/services/destroyed.service.ts
+++ b/packages/core/src/lib/services/destroyed.service.ts
@@ -1,10 +1,14 @@
-import { Injectable, OnDestroy } from '@angular/core';
+import { DestroyRef, inject, Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
 
 @Injectable()
-export class DestroyedSubject extends Subject<void> implements OnDestroy {
-  ngOnDestroy(): void {
-    this.next();
-    this.complete();
+export class DestroyedSubject extends Subject<void> {
+  constructor() {
+    super();
+
+    inject(DestroyRef).onDestroy(() => {
+      this.next();
+      this.complete();
+    });
   }
 }

--- a/packages/core/src/lib/services/evaluator.service.ts
+++ b/packages/core/src/lib/services/evaluator.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { AnyObject, SafeAny } from '@ngify/types';
+import type { AnyObject, SafeAny } from '@ngify/types';
 
 const RETURN_STR = 'return ';
 const STATIC_EXPRESSION_PATTERN = /^{{.+}}$/;

--- a/packages/core/src/lib/services/value-transformer.service.ts
+++ b/packages/core/src/lib/services/value-transformer.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { AnyObject, SafeAny } from '@ngify/types';
+import type { AnyObject, SafeAny } from '@ngify/types';
 import { isFunction, isString } from '../utils';
 import { CodeEvaluator, isStaticExpression } from './evaluator.service';
 

--- a/packages/core/src/lib/tokens.ts
+++ b/packages/core/src/lib/tokens.ts
@@ -1,8 +1,8 @@
-import { InjectionToken, TemplateRef, Type } from '@angular/core';
-import { SafeAny } from '@ngify/types';
-import { AbstractFormContentComponent, AbstractFormItemContentComponent } from './components';
-import { SchemaConfig } from './interfaces';
-import { AbstractWidget } from './widgets/widget';
+import { InjectionToken, type TemplateRef, type Type } from '@angular/core';
+import type { SafeAny } from '@ngify/types';
+import type { AbstractFormContentComponent, AbstractFormItemContentComponent } from './components';
+import type { SchemaConfig } from './interfaces';
+import type { AbstractWidget } from './widgets/widget';
 
 export const WIDGET_MAP = new InjectionToken<Map<string, Type<AbstractWidget<unknown>>>>('');
 

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -1,5 +1,5 @@
-import { EventEmitter, OutputRef, Signal } from '@angular/core';
-import { PickProperty, SafeAny } from '@ngify/types';
+import type { EventEmitter, OutputRef, Signal } from '@angular/core';
+import type { PickProperty, SafeAny } from '@ngify/types';
 
 /**
  * Attribute map for HTML elements.

--- a/packages/core/src/lib/utils/form.utils.ts
+++ b/packages/core/src/lib/utils/form.utils.ts
@@ -1,9 +1,9 @@
 import { inject, Injectable } from '@angular/core';
-import { AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
-import { AnyArray, AnyObject, SafeAny } from '@ngify/types';
-import { AbstractControlSchema, AbstractFormArraySchema, AbstractFormGroupSchema, AbstractSchema, SchemaKey } from '../schemas';
+import { AbstractControl, type AbstractControlOptions, FormArray, FormControl, FormGroup, type ValidatorFn, Validators } from '@angular/forms';
+import type { AnyArray, AnyObject, SafeAny } from '@ngify/types';
+import type { AbstractControlSchema, AbstractFormArraySchema, AbstractFormGroupSchema, AbstractSchema, SchemaKey } from '../schemas';
 import { ValueTransformer } from '../services';
-import { Indexable } from '../types';
+import type { Indexable } from '../types';
 import { isArray, isNumber, isUndefined } from './is.utils';
 import { SchemaUtil } from './schema.utils';
 import { ValueUtil } from './value.utils';

--- a/packages/core/src/lib/utils/is.utils.ts
+++ b/packages/core/src/lib/utils/is.utils.ts
@@ -1,4 +1,4 @@
-import { SafeAny } from '@ngify/types';
+import type { SafeAny } from '@ngify/types';
 
 export const isObject = (o: unknown): o is object => typeof o === 'object';
 export const isNumber = (o: unknown): o is number => typeof o === 'number';

--- a/packages/core/src/lib/utils/model.utils.ts
+++ b/packages/core/src/lib/utils/model.utils.ts
@@ -1,8 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { FormArray, FormGroup } from '@angular/forms';
-import { AnyArray, AnyObject } from '@ngify/types';
-import { AbstractSchema } from '../schemas';
-import { Indexable } from '../types';
+import type { AnyArray, AnyObject } from '@ngify/types';
+import type { AbstractSchema } from '../schemas';
+import type { Indexable } from '../types';
 import { FormUtil, getChildControl } from './form.utils';
 import { SchemaUtil } from './schema.utils';
 import { ValueUtil } from './value.utils';

--- a/packages/core/src/lib/utils/schema.utils.ts
+++ b/packages/core/src/lib/utils/schema.utils.ts
@@ -1,11 +1,11 @@
 import { inject, Injectable } from '@angular/core';
-import { ValidatorFn, Validators } from '@angular/forms';
+import { type ValidatorFn, Validators } from '@angular/forms';
 import { throwWidgetNotFoundError } from '../errors';
 import { SCHEMA_PATCHERS } from '../patcher';
-import { AbstractBranchSchema, AbstractComponentContainerSchema, AbstractComponentWrapperSchema, AbstractControlContainerSchema, AbstractControlSchema, AbstractControlWrapperSchema, AbstractSchema, SchemaKey, SingleSchemaKey } from '../schemas';
-import { SchemaLike, SchemaType } from '../schemas/interfaces';
+import type { AbstractBranchSchema, AbstractComponentContainerSchema, AbstractComponentWrapperSchema, AbstractControlContainerSchema, AbstractControlSchema, AbstractControlWrapperSchema, AbstractSchema, SchemaKey, SingleSchemaKey } from '../schemas';
+import { type SchemaLike, SchemaType } from '../schemas/interfaces';
 import { SCHEMA_MAP } from '../tokens';
-import { Indexable } from '../types';
+import type { Indexable } from '../types';
 import { isArray, isString } from './is.utils';
 
 const ANY_SCHEMA_SELECTOR = '*';

--- a/packages/core/src/lib/utils/value.utils.ts
+++ b/packages/core/src/lib/utils/value.utils.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
-import { AbstractControl } from '@angular/forms';
-import { AnyArray, AnyObject } from '@ngify/types';
-import { AbstractControlSchema } from '../schemas';
+import type { AbstractControl } from '@angular/forms';
+import type { AnyArray, AnyObject } from '@ngify/types';
+import type { AbstractControlSchema } from '../schemas';
 import { isUndefined } from './is.utils';
 import { SchemaUtil } from './schema.utils';
 

--- a/packages/core/src/lib/widgets/row/row.widget.ts
+++ b/packages/core/src/lib/widgets/row/row.widget.ts
@@ -3,8 +3,8 @@ import { Component } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FluentBindingDirective, FluentContextGuardDirective, FluentFormItemOutletDirective, FluentGridModule } from '../../directives';
 import { FluentColumnPipe, FluentControlPipe, FluentReactivePipe, RenderablePipe } from '../../pipes';
-import { RowComponentSchema } from '../../schemas';
-import { AbstractWidget, WidgetTemplateContext } from '../widget';
+import type { RowComponentSchema } from '../../schemas';
+import { AbstractWidget, type WidgetTemplateContext } from '../widget';
 
 type RowWidgetTemplateContext = WidgetTemplateContext<RowComponentSchema, FormGroup>;
 

--- a/packages/core/src/lib/widgets/use.ts
+++ b/packages/core/src/lib/widgets/use.ts
@@ -1,5 +1,5 @@
-import { FluentFormWidgetConfig } from '../features';
-import { RowComponentSchema, SchemaType } from '../schemas';
+import type { FluentFormWidgetConfig } from '../features';
+import { type RowComponentSchema, SchemaType } from '../schemas';
 import { RowWidget } from './row/row.widget';
 
 export function useRowWidget(): FluentFormWidgetConfig<RowComponentSchema> {

--- a/packages/core/src/lib/widgets/widget.ts
+++ b/packages/core/src/lib/widgets/widget.ts
@@ -1,8 +1,8 @@
 import { Directive } from '@angular/core';
 import { AbstractControl, FormControl } from '@angular/forms';
-import { AnyObject } from '@ngify/types';
+import type { AnyObject } from '@ngify/types';
 import { TemplateRefHolder } from '../directives';
-import { AbstractSchema } from '../schemas';
+import type { AbstractSchema } from '../schemas';
 
 export interface WidgetTemplateContext<S extends AbstractSchema, C extends AbstractControl = FormControl> {
   schema: S;

--- a/packages/core/tsconfig.lib.json
+++ b/packages/core/tsconfig.lib.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": []
+    "types": [],
+    "verbatimModuleSyntax": true
   },
   "exclude": [
     "test-setup.ts",


### PR DESCRIPTION
Skips transforming or eliding any imports or exports not marked as type-only.